### PR TITLE
Speculatively test :has-slotted() flattened through multiple slot elements

### DIFF
--- a/css/css-scoping/has-slotted-007.tentative.html
+++ b/css/css-scoping/has-slotted-007.tentative.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        slot {
+          display: block;
+          width: 100px;
+          height: 100px;
+          background-color: red;
+        }
+        :has-slotted {
+          background-color: green;
+        }
+      </style>
+      <slot></slot>
+    </template>
+</div>

--- a/css/css-scoping/has-slotted-flattened-001.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-001.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted(*) flattened through multiple slots</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host">
+			<template shadowrootmode="open">
+			  <style>
+				slot {
+				  display: block;
+				  width: 100px;
+				  height: 100px;
+				  background-color: red;
+				}
+				:has-slotted(*) {
+				  background-color: green;
+				}
+			  </style>
+			  <slot></slot>
+			</template>
+			<slot></slot>
+		</div>
+	</template>
+	<div></div>
+</div>

--- a/css/css-scoping/has-slotted-flattened-002.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-002.tentative.html
@@ -4,18 +4,20 @@
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>
-<div id="host"><template shadowrootmode="open">
-    <style>
-    slot {
-        display: block;
-        width: 100px;
-        height: 100px;
-        background-color: green;
-    }
-    :has-slotted(*),
-	:has-slotted {
-        background-color: red;
-    }
-    </style>
-    <slot></slot>
+<div id="ancestor"><template shadowrootmode="open">
+	<div id="host"><template shadowrootmode="open">
+		<style>
+		slot {
+			display: block;
+			width: 100px;
+			height: 100px;
+			background-color: green;
+		}
+		:has-slotted(*),
+		:has-slotted {
+			background-color: red;
+		}
+		</style>
+		<slot></slot>
+	</template><slot></slot></div>
 </template></div>

--- a/css/css-scoping/has-slotted-flattened-003.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-003.tentative.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted(...) flatted through multiple slots, negative test: no children, but whitespace present</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host">
+			<template shadowrootmode="open">
+				<style>
+				slot {
+					display: block;
+					width: 100px;
+					height: 100px;
+					background-color: green;
+				}
+				:has-slotted(*) {
+					background-color: red;
+				}
+				</style>
+				<slot></slot>
+			</template>
+		</div>
+		<slot></slot>
+	</template>
+</div>

--- a/css/css-scoping/has-slotted-flattened-004.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-004.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted(.class) flattened through multiple slots</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host">
+			<template shadowrootmode="open">
+			  <style>
+				slot {
+				  display: block;
+				  width: 100px;
+				  height: 100px;
+				  background-color: red;
+				}
+				:has-slotted(.slotted-element) {
+				  background-color: green;
+				}
+			  </style>
+			  <slot></slot>
+			</template>
+			<slot></slot>
+		</div>
+	</template>
+    <div class="slotted-element"></div>
+</div>

--- a/css/css-scoping/has-slotted-flattened-005.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-005.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted(.class) flattened through multiple slots, negative test</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host">
+			<template shadowrootmode="open">
+			  <style>
+				slot {
+				  display: block;
+				  width: 100px;
+				  height: 100px;
+				  background-color: green;
+				}
+				:has-slotted(.not-slotted-element) {
+				  background-color: red;
+				}
+			  </style>
+			  <slot></slot>
+			</template>
+			<slot></slot>
+		</div>
+	</template>
+    <div class="slotted-element"></div>
+</div>

--- a/css/css-scoping/has-slotted-flattened-006.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-006.tentative.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted(el) + :has-slotted(el) flattened through multiple slots</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host">
+			<template shadowrootmode="open">
+			  <style>
+				[name] {
+				  display: block;
+				  width: 100px;
+				  height: 100px;
+				  background-color: red;
+				}
+				:has-slotted(div) + :has-slotted(div) {
+				  background-color: green;
+				}
+			  </style>
+			  <slot></slot>
+			  <slot name="after"></slot>
+			</template>
+			<slot></slot>
+			<slot name="after" slot="after"></slot>
+		</div>
+	</template>
+	<div></div>
+	<div slot="after"></div>
+</div>

--- a/css/css-scoping/has-slotted-flattened-007.tentative.html
+++ b/css/css-scoping/has-slotted-flattened-007.tentative.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:has-slotted flattened through multiple slots</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="ancestor">
+	<template shadowrootmode="open">
+		<div id="host"><template shadowrootmode="open">
+			<style>
+			slot {
+				display: block;
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+			:has-slotted {
+				background-color: green;
+			}
+			</style>
+			<slot></slot>
+		</template><slot></slot></div>
+	</template>
+</div>

--- a/css/selectors/parsing/parse-has-slotted.tentative.html
+++ b/css/selectors/parsing/parse-has-slotted.tentative.html
@@ -24,8 +24,8 @@
   test_valid_selector(":not(:has-slotted(foo))");
   test_valid_selector(":has-slotted(div + div)");
   test_valid_selector(":has-slotted(div:has(> span))");
+  test_valid_selector(":has-slotted");
   test_invalid_selector("::has-slotted(foo)");
-  test_invalid_selector(":has-slotted");
   test_invalid_selector(":has-slotted()");
   test_invalid_selector(":has-slotted(0)");
   test_invalid_selector(":has-slotted(div > span)");


### PR DESCRIPTION
- slotted content flattened through many slots
- `:has-slotted` in parsing and visual tests